### PR TITLE
Snowflake settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 logs
 *.log
 .DS_Store
-.vscode
+.vscode/*
+.idea
 Thumbs.db
 
 # Node
@@ -15,6 +16,7 @@ node_modules
 # Dev + test
 coverage
 .env.test
+!.vscode/launch.json
 
 # Fix for img/spoiler directory
 /img/spoilers/gifs/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "env": {
+                "NODE_ENV": "test"
+            },
+            "program": "${workspaceFolder}/index.js"
+        }
+    ]
+}

--- a/commands/Useful/settings.js
+++ b/commands/Useful/settings.js
@@ -114,7 +114,12 @@ const validateType = (input, expectedType, settingConfig) => {
 
       // input is a number in given range
       case 'range': {
-        if (!settingConfig || !settingConfig.min || !settingConfig.max) return [false, null];
+        if (
+          !settingConfig
+          || !('min' in settingConfig)
+          || !('max' in settingConfig)
+        ) return [false, null];
+
         const num = parseFloat(input);
 
         return [num >= settingConfig.min && num <= settingConfig.max, Number(input)];

--- a/test/data/index.js
+++ b/test/data/index.js
@@ -20,6 +20,12 @@ exports.serverSettings = {
     string: {
       type: 'string',
     },
+    textChannel: {
+      type: 'textChannel',
+    },
+    user: {
+      type: 'user',
+    },
     arrayOfStrings: {
       type: 'array',
       innerType: 'string',
@@ -41,6 +47,16 @@ exports.serverSettings = {
       type: 'array',
       innerType: 'boolean',
       description: 'An array of booleans',
+    },
+    arrayOfTextChannels: {
+      type: 'array',
+      innerType: 'textChannel',
+      description: 'An array of text channels',
+    },
+    arrayOfUsers: {
+      type: 'array',
+      innerType: 'user',
+      description: 'An array of users',
     },
   },
 };

--- a/test/data/index.js
+++ b/test/data/index.js
@@ -1,7 +1,7 @@
 /** @type {import('../../commands/Useful/settings').ServerSettings} */
 exports.serverSettings = {
   test: {
-    'range 0-10': {
+    range: {
       type: 'range',
       min: 0,
       max: 10,

--- a/test/testHelpers.js
+++ b/test/testHelpers.js
@@ -2,10 +2,19 @@ const { Collection } = require('discord.js');
 const defaultSettings = require('../settings.example.json');
 
 exports.MOCK_GUILD_ID = 'MOCK_GUILD_ID';
-exports.MOCK_CHANNEL_ID = 'MOCK_CHANNEL_ID';
+exports.MOCK_CHANNEL_ID = '987654321';
+exports.MOCK_USER_ID = '123456789';
+
 exports.MOCK_GUILD = {
   id: this.MOCK_GUILD_ID,
 };
+exports.MOCK_CHANNEL = {
+  id: this.MOCK_CHANNEL_ID,
+};
+exports.MOCK_USER = {
+  id: this.MOCK_USER_ID,
+};
+
 exports.MOCK_BOT = {
   clearMocks: () => {
     this.MOCK_BOT.message.reply.mockClear();
@@ -24,6 +33,12 @@ exports.MOCK_BOT = {
   },
   guilds: new Collection([
     [this.MOCK_GUILD_ID, this.MOCK_GUILD],
+  ]),
+  channels: new Collection([
+    [this.MOCK_CHANNEL_ID, this.MOCK_CHANNEL],
+  ]),
+  users: new Collection([
+    [this.MOCK_USER_ID, this.MOCK_USER],
   ]),
   guildOverrides: {},
 };

--- a/test/unit/commands/settings.test.js
+++ b/test/unit/commands/settings.test.js
@@ -2,7 +2,9 @@ const fs = require('fs');
 const path = require('path');
 const waitForExpect = require('wait-for-expect');
 const settingsCommand = require('../../../commands/Useful/settings');
-const { MOCK_BOT, MOCK_GUILD_ID, makeMockMessage } = require('../../testHelpers');
+const {
+  MOCK_BOT, MOCK_GUILD_ID, MOCK_CHANNEL_ID, MOCK_USER_ID, makeMockMessage,
+} = require('../../testHelpers');
 const { serverSettings: testServerSettings } = require('../../data');
 
 const pathToMockGuildConfig = path.resolve(__dirname, `../../../config/guilds/${MOCK_GUILD_ID}.json`);
@@ -62,11 +64,15 @@ describe('Settings Command', () => {
     ['range', ['0'], 0],
     ['range', ['5'], 5],
     ['range', ['10'], 10],
+    ['textChannel', [`<#${MOCK_CHANNEL_ID}>`], `"${MOCK_CHANNEL_ID}"`],
+    ['user', [`<!@${MOCK_USER_ID}>`], `"${MOCK_USER_ID}"`],
     ['arrayOfStrings', ['one', 'two'], '\\[\\s*"one",\\s*"two"\\s*\\]'],
     ['arrayOfStrings', ['1337', '12345678900987654321'], '\\[\\s*"1337",\\s*"12345678900987654321"\\s*\\]'],
     ['arrayOfNumbers', ['1', '2', '3'], '\\[\\s*1,\\s*2,\\s*3\\s*\\]'],
     ['arrayOfBooleans', ['true', 'false'], '\\[\\s*true,\\s*false\\s*\\]'],
     ['arrayOfRanges', ['1', '5', '10'], '\\[\\s*1,\\s*5,\\s*10\\s*\\]'],
+    ['arrayOfTextChannels', [`<#${MOCK_CHANNEL_ID}>`], `\\[\\s*"${MOCK_CHANNEL_ID}"\\s*\\]`],
+    ['arrayOfUsers', [`<!@${MOCK_USER_ID}>`], `\\[\\s*"${MOCK_USER_ID}"\\s*\\]`],
   ])('setting of type `%s` with input "%s" sets to correct value successfully`', async (type, value, expectation) => {
     const args = ['!settings', 'test', type, ...value];
 
@@ -79,6 +85,10 @@ describe('Settings Command', () => {
     ['boolean', ['not-boolean']],
     ['range', ['-1']],
     ['range', ['11']],
+    ['textChannel', ['#not-really-a-text-channel']],
+    ['textChannel', ['<#999999999>']],
+    ['user', ['@NotAUser']],
+    ['user', ['<!@999999999>']],
     ['arrayOfNumbers', ['not', 'numbers']],
     ['arrayOfBooleans', ['not', 'booleans']],
     ['arrayOfRanges', ['not', 'in', 'range']],

--- a/test/unit/commands/settings.test.js
+++ b/test/unit/commands/settings.test.js
@@ -59,6 +59,9 @@ describe('Settings Command', () => {
     ['number', ['10'], 10],
     ['boolean', ['true'], true],
     ['boolean', ['false'], false],
+    ['range', ['0'], 0],
+    ['range', ['5'], 5],
+    ['range', ['10'], 10],
     ['arrayOfStrings', ['one', 'two'], '\\[\\s*"one",\\s*"two"\\s*\\]'],
     ['arrayOfStrings', ['1337', '12345678900987654321'], '\\[\\s*"1337",\\s*"12345678900987654321"\\s*\\]'],
     ['arrayOfNumbers', ['1', '2', '3'], '\\[\\s*1,\\s*2,\\s*3\\s*\\]'],
@@ -74,6 +77,8 @@ describe('Settings Command', () => {
   test.each([
     ['number', ['foo']],
     ['boolean', ['not-boolean']],
+    ['range', ['-1']],
+    ['range', ['11']],
     ['arrayOfNumbers', ['not', 'numbers']],
     ['arrayOfBooleans', ['not', 'booleans']],
     ['arrayOfRanges', ['not', 'in', 'range']],


### PR DESCRIPTION
- Adds text channels and users as server setting types.
- Accepts inputs as `#text-channel` and `@User` mentions, as well as pure Snowflake strings of the respective IDs.

Closes #85 