### PR TITLE
Add command channel settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ insert_final_newline = true
 [*.yml]
 indent_style = space
 indent_size = 4
+
+[*.md]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,11 +2,11 @@ root = true
 
 [*]
 end_of_line = lf
+insert_final_newline = true
 
 [*.js]
 indent_style = space
 indent_size = 2
-insert_final_newline = true
 
 [*.yml]
 indent_style = space

--- a/commands/README.md
+++ b/commands/README.md
@@ -16,9 +16,79 @@ These exports are detailed further below
 
 ### <a id="exports-help"></a>`exports.help`
 
+This is the information for the `!help` menus related to the command. It expects the following:
+
+```ts
+exports.help = {
+    name: string, // the command name
+    description: string,  // description of the command
+    usage: // usage examples
+    // this can be a string or a function that returns a string
+        string ||
+        function(
+            bot: Discord.Client,
+            message: Discord.Message
+        ) => string;
+};
+```
+
+If usage examples contain the command prefix in some way (ie: usage: "!help lfg"), switch the usage to a function & replace the instances of the command prefix with calls from `getGuildCommandPrefix(...)` so that the help menus reflect the given guild's settings config.
+
+For example:
+
+```js
+exports.help = {
+  name: 'example',
+  description: 'Example of using `getGuildCommandPrefix` in a help menu',
+  usage: (bot, message) => {
+    const prefix = getGuildCommandPrefix(bot, message);
+
+    return `
+Examples ::
+
+${prefix}example make a bot 🤖
+${prefix}example make good coffee ☕
+`.trim();
+  }
+}
+```
+
 ### <a id="exports-conf"></a>`exports.conf`
 
+This is the configuration for the given command. Here are the available options for configuration per comamnd:
+
+* **enabled**
+  * `boolean`
+  * Whether or not the command is able to be used currently. Set to `false` to disable
+* **visible**
+  * `boolean`
+  * Whether the command is visible within help menus
+* **guildOnly**
+  * `boolean`
+  * `true` sets the command to only work within the `mainGuild`
+* **textChannelOnly**
+  * `boolean`
+  * Command will only work in a server text channel (ie: not in a DM with the bot)
+* **aliases**
+  * `array<string>`
+  * List of alternative names to execute the command with
+* **permLevel**
+  * `number` 
+  * Minimum permission level allowed to use the command
+  * See perm. level docs in the source code comments within `handlers/Setup` for more details on what the different permission levels are
+
 ### <a id="exports-run"></a>`exports.run`
+
+This is the function that runs and executes the command. It is a void function with the following arguments available:
+
+```ts
+exports.run = (
+  bot: Discord.Client, // the bot
+  message: Discord.Message, // message from command usage
+  args: array<string>, // array of command arguments sent by user
+  perms: number // permission level of user
+)
+```
 
 ## Category Folders
 
@@ -26,3 +96,25 @@ These exports are detailed further below
 - Memes
 - Random
 - Useful
+
+Commands are automatically assigned to the category associated with the folder and in accordance to the command category configuration designated in the `settings.json` config.
+
+eg:
+
+```json
+// settings.json
+{
+  "commandGroups": [
+    {
+      "code": [
+        "debug",
+        "support"
+      ],
+      // `name` should match up with folder name
+      "name": "Debug & Support",
+      "description": "Help menus & debug"
+    },
+    // etc...
+  ]
+}
+```

--- a/commands/README.md
+++ b/commands/README.md
@@ -32,9 +32,9 @@ exports.help = {
 };
 ```
 
-If usage examples contain the command prefix in some way (ie: usage: "!help lfg"), switch the usage to a function & replace the instances of the command prefix with calls from `getGuildCommandPrefix(...)` so that the help menus reflect the given guild's settings config.
+If your usage examples contain the command prefix in some way (ie: usage: "!help lfg"), switch `usage` to a function & replace the instances of the command prefix with calls from `getGuildCommandPrefix(...)` so that the help menus reflect the given guild's configured command prefix.
 
-For example:
+eg:
 
 ```js
 exports.help = {
@@ -75,7 +75,7 @@ This is the configuration for the given command. Here are the available options 
 * **permLevel**
   * `number` 
   * Minimum permission level allowed to use the command
-  * See perm. level docs in the source code comments within `handlers/Setup` for more details on what the different permission levels are
+  * See perm. level docs in the source code comments within [`handlers/Setup`](https://github.com/malouro/ggis-bot/blob/master/handlers/Setup.js#L66) for more details on what the different permission levels are
 
 ### <a id="exports-run"></a>`exports.run`
 
@@ -87,7 +87,7 @@ exports.run = (
   message: Discord.Message, // message from command usage
   args: array<string>, // array of command arguments sent by user
   perms: number // permission level of user
-)
+) => void
 ```
 
 ## Category Folders

--- a/commands/Useful/settings.js
+++ b/commands/Useful/settings.js
@@ -111,7 +111,7 @@ const validateType = (input, expectedType, settingConfig, bot) => {
 
       // input is integer
       case 'integer':
-        return [Number.isInteger(input), Number(input)];
+        return [Number.isInteger(Number(input)), Number(input)];
 
       // input is a number in given range
       case 'range': {
@@ -126,7 +126,7 @@ const validateType = (input, expectedType, settingConfig, bot) => {
         return [num >= settingConfig.min && num <= settingConfig.max, num];
       }
 
-      // Allow for strings that look like numbers or Snowflakes
+      // Allow for strings that look like numbers (or Snowflakes)
       case 'string':
       case 'textChannel':
       case 'user':
@@ -159,6 +159,12 @@ const validateType = (input, expectedType, settingConfig, bot) => {
   return [expectedType === 'string', input];
 };
 
+/**
+ * Returns description for given config setting
+ *
+ * @param {ServerSettingKey} setting
+ * @return {string} Setting description
+ */
 const getTypeDesc = (setting) => {
   const { type } = setting;
   switch (type) {
@@ -170,11 +176,20 @@ const getTypeDesc = (setting) => {
       return 'integer (whole number)';
     case 'range':
       return `number between ${setting.min || 0} and ${setting.max || Infinity}`;
+    case 'array':
+      return `array of \`${setting.innerType || 'string'}\`s`;
+    case 'textChannel':
+      return 'text channel (`#text-channel` or channel ID)';
+    case 'user':
+      return 'user (`@User` mention or user ID)';
     default:
       return 'string';
   }
 };
 
+/**
+ * @return {string} Description of all available config settings
+ */
 const getAllSettings = () => {
   let message = "Here's the full list of settings that can be configured:\n\n```asciidoc\n";
   const scopes = Object.keys(configOptions);
@@ -211,8 +226,8 @@ ${commandName} <scope> (<setting> <value>)
 <scope> is required and can be any of the following:
 
 - list :: List all available settings
-- show :: show current config for the server
-${scopes.map(scope => `- ${scope} :: ${configOptions[scope].description}`).join('\n')}
+- show :: Show current config for the server
+${scopes.map(scope => `- ${scope} :: ${configOptions[scope].description || '<no description>'}`).join('\n')}
 
 If <scope> is *not* "list" or "show", you must also provide <setting> and <value> options. Use "${prefix}${commandName} list" for more info on available settings & values options.
 
@@ -234,7 +249,6 @@ exports.conf = {
   permLevel: 3,
 };
 
-/* eslint-disable-next-line no-unused-vars */
 exports.run = async (bot, message, args) => {
   const prefix = getGuildCommandPrefix(bot, message);
   const getCurrentGuildConfig = (input) => {

--- a/commands/Useful/settings.js
+++ b/commands/Useful/settings.js
@@ -51,6 +51,32 @@ const configOptions = {
     },
   },
 
+  commandChannels: {
+    description: 'Controls where and how commands are allowed to be used',
+    enabled: {
+      type: 'boolean',
+      default: settings.commandChannels.enabled,
+      description: 'Enables control of command channels',
+    },
+    whitelist: {
+      type: 'array',
+      innerType: 'textChannel',
+      default: settings.commandChannels.whitelist,
+      description: 'List of channels where command usage is allowed',
+    },
+    blacklist: {
+      type: 'array',
+      innerType: 'textChannel',
+      default: settings.commandChannels.blacklist,
+      description: 'List of channels where command usage is NOT allowed',
+    },
+    strictMode: {
+      type: 'boolean',
+      default: settings.commandChannels.strictMode,
+      description: 'If on: deletes non-command messages in whitelist channels & commands in blacklist channels',
+    },
+  },
+
   // =================== Example: ===================
   // lfg: {
   //   create_temp_channel: {
@@ -64,6 +90,41 @@ const configOptions = {
   // For testing purposes only:
   ...(process.env.NODE_ENV === 'test' ? testServerSettings : {}
   ),
+};
+
+exports.help = {
+  name: commandName,
+  description: "Change the bot's server settings",
+  usage: (bot, message) => {
+    const prefix = getGuildCommandPrefix(bot, message);
+    const scopes = Object.keys(configOptions);
+    return `
+${commandName} <scope> (<setting> <value>)
+
+<scope> is required and can be any of the following:
+
+- list :: List all available settings
+- show :: Show current config for the server
+${scopes.map(scope => `- ${scope} :: ${configOptions[scope].description || '<no description>'}`).join('\n')}
+
+If <scope> is *not* "list" or "show", you must also provide <setting> and <value> options. Use "${prefix}${commandName} list" for more info on available settings & values options.
+
+Examples ::
+
+${prefix}${commandName} show            ║ Shows the current config for the server, pretty-printed
+${prefix}${commandName} list            ║ Shows all available settings that can be modified
+${prefix}${commandName} bot prefix $    ║ Changes command prefix to "$" in this server
+`.trim();
+  },
+};
+
+exports.conf = {
+  enabled: true,
+  visible: true,
+  guildOnly: false,
+  textChannelOnly: true,
+  aliases: [],
+  permLevel: 3,
 };
 
 /**
@@ -212,41 +273,6 @@ const getAllSettings = () => {
 
   message += '```';
   return message;
-};
-
-exports.help = {
-  name: commandName,
-  description: "Change the bot's server settings",
-  usage: (bot, message) => {
-    const prefix = getGuildCommandPrefix(bot, message);
-    const scopes = Object.keys(configOptions);
-    return `
-${commandName} <scope> (<setting> <value>)
-
-<scope> is required and can be any of the following:
-
-- list :: List all available settings
-- show :: Show current config for the server
-${scopes.map(scope => `- ${scope} :: ${configOptions[scope].description || '<no description>'}`).join('\n')}
-
-If <scope> is *not* "list" or "show", you must also provide <setting> and <value> options. Use "${prefix}${commandName} list" for more info on available settings & values options.
-
-Examples ::
-
-${prefix}${commandName} show            ║ Shows the current config for the server, pretty-printed
-${prefix}${commandName} list            ║ Shows all available settings that can be modified
-${prefix}${commandName} bot prefix $    ║ Changes command prefix to "$" in this server
-`.trim();
-  },
-};
-
-exports.conf = {
-  enabled: true,
-  visible: true,
-  guildOnly: false,
-  textChannelOnly: true,
-  aliases: [],
-  permLevel: 3,
 };
 
 exports.run = async (bot, message, args) => {

--- a/commands/Useful/settings.js
+++ b/commands/Useful/settings.js
@@ -58,6 +58,12 @@ const configOptions = {
       default: settings.commandChannels.enabled,
       description: 'Enables control of command channels',
     },
+    locklist: {
+      type: 'array',
+      innerType: 'textChannel',
+      default: settings.commandChannels.locklist,
+      description: 'List of channels that ONLY accept command usage',
+    },
     whitelist: {
       type: 'array',
       innerType: 'textChannel',
@@ -73,7 +79,7 @@ const configOptions = {
     strictMode: {
       type: 'boolean',
       default: settings.commandChannels.strictMode,
-      description: 'If on: deletes non-command messages in whitelist channels & commands in blacklist channels',
+      description: 'If on: deletes non-compliant messages g',
     },
   },
 
@@ -103,17 +109,19 @@ ${commandName} <scope> (<setting> <value>)
 
 <scope> is required and can be any of the following:
 
-- list :: List all available settings
-- show :: Show current config for the server
+- list  :: List all available settings
+- show  :: Show current config for the server
+- reset :: Reset a specific setting, or all settings
 ${scopes.map(scope => `- ${scope} :: ${configOptions[scope].description || '<no description>'}`).join('\n')}
 
 If <scope> is *not* "list" or "show", you must also provide <setting> and <value> options. Use "${prefix}${commandName} list" for more info on available settings & values options.
 
 Examples ::
 
-${prefix}${commandName} show            ║ Shows the current config for the server, pretty-printed
-${prefix}${commandName} list            ║ Shows all available settings that can be modified
-${prefix}${commandName} bot prefix $    ║ Changes command prefix to "$" in this server
+${prefix}${commandName} show             ║ Shows the current config for the server
+${prefix}${commandName} list             ║ Shows all available settings that can be modified
+${prefix}${commandName} reset bot prefix ║ Reset the bot prefix for this server
+${prefix}${commandName} bot prefix $     ║ Changes command prefix to "$" in this server
 `.trim();
   },
 };

--- a/commands/Useful/settings.js
+++ b/commands/Useful/settings.js
@@ -380,6 +380,7 @@ exports.run = async (bot, message, args) => {
       scope,
       key,
     ).catch((err) => {
+      errorOnReset = err;
       console.error(err);
       message.reply([
         'Uh-oh, something went wrong trying to remove that setting override.',
@@ -387,7 +388,6 @@ exports.run = async (bot, message, args) => {
         '',
         `Check \`${prefix}settings show\` to see this server's setting configuration.`,
       ].join('\n'));
-      errorOnReset = err;
     });
 
     if (errorOnReset) return null;
@@ -426,12 +426,19 @@ ${getCurrentGuildConfig(configAfterReset)}
     );
   }
 
+  let errorOnUpdate = null;
   const updatedConfig = await updateGuildConfig(bot, message.guild.id, scope, key, castedValue)
     .catch((err) => {
+      errorOnUpdate = err;
       console.error(err);
-      message.reply('Uh-oh. Something went wrong trying to save the server config! :(');
+      message.reply([
+        'Uh-oh, something went wrong trying to save or update the server\'s settings.',
+        '',
+        `Check \`${prefix}settings show\` to see this server's current configuration.`,
+      ].join('\n'));
     });
 
+  if (errorOnUpdate) return null;
   return message.reply(`
 Successful change of \`${scope}.${key}\` to \`${value}\`!
 

--- a/events/commands.js
+++ b/events/commands.js
@@ -72,6 +72,9 @@ module.exports = (bot, message, settings, prefix) => {
     cmd = bot.commands.get(bot.aliases.get(command));
   }
 
+  /**
+   * Check if the current channel is white/blacklisted for command only channels
+   */
   const [disallowed, deleteMessage] = validateCommandOnly(bot, message, Boolean(cmd), settings);
 
   if (deleteMessage) {
@@ -79,7 +82,7 @@ module.exports = (bot, message, settings, prefix) => {
     message.delete();
     return;
   }
-  if (disallowed) return;
+  if (disallowed) return; // ignore if message/command is disallowed
 
   // if something was found, check to see if we can appropriately run the command
   if (cmd) {

--- a/events/commands.js
+++ b/events/commands.js
@@ -14,6 +14,8 @@
 const chalk = require('chalk');
 const moment = require('moment');
 const validateCommandOnly = require('./messageFeatures/commandOnlyChannels');
+const { getGuildSpecificSetting } = require('../handlers/GuildSettings');
+const { conf: { permLevel: settingsCommandPermLevel } } = require('../commands/Useful/settings');
 
 const checkIfAbleToUse = (cmd, perms, message, settings) => {
   /**
@@ -53,7 +55,11 @@ module.exports = (bot, message, settings, prefix) => {
       );
   }
 
-  if (!message.content.startsWith(prefix)) return;
+  if (!message.content.startsWith(prefix)) {
+    const locklist = getGuildSpecificSetting(bot, message, 'commandChannels', 'locklist', []);
+
+    if (!locklist || locklist.length === 0) return;
+  }
 
   const args = message.content.substring(prefix.length).split(/ +/);
   const command = args[0].toLowerCase();
@@ -72,17 +78,20 @@ module.exports = (bot, message, settings, prefix) => {
     cmd = bot.commands.get(bot.aliases.get(command));
   }
 
-  /**
-   * Check if the current channel is white/blacklisted for command only channels
-   */
-  const [disallowed, deleteMessage] = validateCommandOnly(bot, message, Boolean(cmd), settings);
+  // if able to use !settings; allow command to go thru anyway
+  // this is in case settings are corrupt, or are configured in a way that prohibits commands *everywhere*
+  // to allow admins to properly reconfigure
+  if (perms < settingsCommandPermLevel) {
+    const [disallowed, deleteMessage] = validateCommandOnly(bot, message, Boolean(cmd), settings);
 
-  if (deleteMessage) {
-    console.log(`[${moment().format(settings.timeFormat)}] Message deleted in ${message.guild.name} > #${message.channel.name}\n${message.author}: "${message.content}"`);
-    message.delete();
-    return;
+    if (disallowed) {
+      if (deleteMessage) {
+        console.log(`[${moment().format(settings.timeFormat)}] Message deleted in ${message.guild.name} > #${message.channel.name}\n${message.author}: "${message.content}"`);
+        message.delete();
+      }
+      return;
+    }
   }
-  if (disallowed) return; // ignore if message/command is disallowed
 
   // if something was found, check to see if we can appropriately run the command
   if (cmd) {

--- a/events/commands.js
+++ b/events/commands.js
@@ -13,6 +13,7 @@
 
 const chalk = require('chalk');
 const moment = require('moment');
+const validateCommandOnly = require('./messageFeatures/commandOnlyChannels');
 
 const checkIfAbleToUse = (cmd, perms, message, settings) => {
   /**
@@ -34,6 +35,12 @@ const checkIfAbleToUse = (cmd, perms, message, settings) => {
   return true;
 };
 
+/**
+ * @param {import('discord.js').Client} bot
+ * @param {import('discord.js').Message} message
+ * @param {JSON} settings Bot settings
+ * @param {string} prefix Command prefix
+ */
 module.exports = (bot, message, settings, prefix) => {
   if (message.content.startsWith(`<@!${bot.user.id}>`)) {
     bot.commands
@@ -64,6 +71,15 @@ module.exports = (bot, message, settings, prefix) => {
   } else if (bot.aliases.has(command)) {
     cmd = bot.commands.get(bot.aliases.get(command));
   }
+
+  const [disallowed, deleteMessage] = validateCommandOnly(bot, message, Boolean(cmd), settings);
+
+  if (deleteMessage) {
+    console.log(`[${moment().format(settings.timeFormat)}] Message deleted in ${message.guild.name} > #${message.channel.name}\n${message.author}: "${message.content}"`);
+    message.delete();
+    return;
+  }
+  if (disallowed) return;
 
   // if something was found, check to see if we can appropriately run the command
   if (cmd) {

--- a/events/messageFeatures/commandOnlyChannels.js
+++ b/events/messageFeatures/commandOnlyChannels.js
@@ -1,0 +1,43 @@
+const { getGuildSpecificSetting } = require('../../handlers/GuildSettings');
+
+/**
+ * Determines whether the command usage / message is allowed or disallowed in the current channel
+ *
+ * @param {import('discord.js').Client} bot The bot
+ * @param {import('discord.js').Message} message Message to examine
+ * @param {boolean} isCommand Did the message contain a command usage?
+ * @param {JSON} settings Bot settings config
+ * @returns {boolean[]} Returns [ commandProhibited, deleteMessage? ] boolean values
+ */
+module.exports = (bot, message, isCommand, settings) => {
+  const getCommandChannelsSetting = setting => getGuildSpecificSetting(
+    bot,
+    message,
+    'commandChannels',
+    setting,
+    settings.commandChannels[setting],
+  );
+
+  const enabled = getCommandChannelsSetting('enabled');
+  /** @type {import('discord.js').Collection} */
+  const whitelist = getCommandChannelsSetting('whitelist');
+  const blacklist = getCommandChannelsSetting('blacklist');
+  const strictModeEnabled = getCommandChannelsSetting('strictMode');
+
+  if (enabled) {
+    // If channel is in blacklist, disallow if it's a command
+    if (blacklist.includes(message.channel.id)) {
+      return [isCommand, strictModeEnabled];
+    }
+    // If channel isn't in the whitelist, disallow if it's a commandS
+    // If none of the whitelist channels exist anymore, always allow
+    if (whitelist.length > 0 && !whitelist.includes(message.channel.id)) {
+      return [
+        isCommand || !whitelist.some(channel => message.guild.channels.has(channel)),
+        strictModeEnabled,
+      ];
+    }
+  }
+
+  return [false, false];
+};

--- a/events/messageFeatures/commandOnlyChannels.js
+++ b/events/messageFeatures/commandOnlyChannels.js
@@ -19,12 +19,16 @@ module.exports = (bot, message, isCommand, settings) => {
   );
 
   const enabled = getCommandChannelsSetting('enabled');
-  /** @type {import('discord.js').Collection} */
+  const locklist = getCommandChannelsSetting('locklist');
   const whitelist = getCommandChannelsSetting('whitelist');
   const blacklist = getCommandChannelsSetting('blacklist');
   const strictModeEnabled = getCommandChannelsSetting('strictMode');
 
   if (enabled) {
+    if (locklist.includes(message.channel.id)) {
+      return [!isCommand, strictModeEnabled];
+    }
+
     // If channel is in blacklist, disallow if it's a command
     if (blacklist.includes(message.channel.id)) {
       return [isCommand, strictModeEnabled];

--- a/handlers/GuildSettings.js
+++ b/handlers/GuildSettings.js
@@ -112,3 +112,34 @@ exports.update = (bot, id, scope, key, value) => new Promise((resolve, reject) =
     resolve(updatedConfig);
   });
 });
+
+/**
+ * Resets/removes a setting within the config
+ * @param {import('discord.js').Client} bot The bot instance
+ * @param {import('discord.js').Snowflake} id ID of the guild
+ * @param {string} scope {scope} in settings
+ * @param {string} key {key} in {scope}
+ * @returns {Promise} result from updated config
+ */
+exports.deleteSetting = (bot, id, scope, key) => new Promise((resolve, reject) => {
+  try {
+    let updatedConfig = bot.guildOverrides[id];
+
+    if (!scope || !key) reject(new Error('`key` or `scope` is missing'));
+    if (scope in bot.guildOverrides[id] && key in bot.guildOverrides[id][scope]) {
+      delete bot.guildOverrides[id][scope][key];
+
+      updatedConfig = bot.guildOverrides[id];
+
+      fs.writeFile(path.resolve(guildConfigsPath, `./${id}.json`), JSON.stringify(bot.guildOverrides[id]), (err) => {
+        if (err) reject(new Error(`Writing to ${guildConfigsPath}/${id}.json failed with the following error:\n${err}`));
+
+        resolve(updatedConfig);
+      });
+    } else {
+      reject(new Error(`Scope "${scope}" or key "${key}" are not currently overridden in this guild. Nothing to reset/remove.`));
+    }
+  } catch (err) {
+    reject(err);
+  }
+});

--- a/settings.example.json
+++ b/settings.example.json
@@ -47,6 +47,13 @@
     },
     "memes": true
   },
+  "commandChannels": {
+    "enabled": true,
+    "locklist": ["Channels that ONLY accept commands", "NO normal messages", "(These are different per-server)"],
+    "whitelist": ["Channels that allow command usage", "(These are different per-server)"],
+    "blacklist": ["Channels that disallow command usage", "(These are different per-server)"],
+    "strictMode": false
+  },
   "helpMenu": {
     "split_value": 20
   },

--- a/settings.template.json
+++ b/settings.template.json
@@ -50,6 +50,7 @@
   },
   "commandChannels": {
     "enabled": true,
+    "locklist": [],
     "whitelist": [],
     "blacklist": [],
     "strictMode": false

--- a/settings.template.json
+++ b/settings.template.json
@@ -48,6 +48,12 @@
     },
     "memes": true
   },
+  "commandChannels": {
+    "enabled": true,
+    "whitelist": [],
+    "blacklist": [],
+    "strictMode": false
+  },
   "helpMenu": {
     "split_value": 20
   },

--- a/test/README.md
+++ b/test/README.md
@@ -11,18 +11,38 @@ Unit tests are tests for specific individual parts of the bot. In this case, tha
 
 > Execute these tests via `yarn test:e2e`
 
-End-to-end tests are tests that connect and run on an actual Discord server. These are tests that run as if it were an actual production running Discord bot, but in a controlled environment on a specified test server with a test bot account.
+End-to-end tests are tests that connect and run on an actual Discord server. These are tests that run ab actual Discord bot, but in a controlled environment on a specified test server with a test bot application.
+
 
 # Setup and Mocks
 
 - Mocks and test helper functions exist within `test/testHelpers` - these help set up and execute the end-to-end & unit tests
-- `settings.example.json` is used as a base for the settings for the `MOCK_BOT`, while other settings are overridden via environment variables.
+- `settings.example.json` is used as a base for the settings for the `MOCK_BOT`, while some other settings are overridden via environment variables.
 
 ## Available environment variables
 
 | Env. Variable | Setting name |
 |---------------|--------------|
+|`TOKEN`        | `token`      |
 |`MASTER_ID`    | `masterID`   |
 |`MAIN_GUILD`   | `mainGuild`  |
 |`TEST_GUILD`   | `testGuild`  |
 |`TEST_CHANNEL` | `mainChannel`|
+
+## End-to-end environment
+
+Test setup and Jest configuration are defined within `test/e2e` while the test files are located in `test/e2e/suite`. Here are some details on how this environment is set up:
+
+- `.env.test` file at the root directory sets up environment variables, here's an example of its content:
+
+```
+TOKEN=<Test bot token>
+TEST_GUILD=<ID of test guild>
+TEST_CHANNEL=<ID of text channel to test in>
+```
+
+> **NEVER commit this file to source** - authorization tokens do not belong in source
+
+- `CI=true` option is provided when ran in CI and tells the test to not read environment variables from the `.env.test.` file
+- `ALL_CLEAR` global flag flips to `true` after tests are done running and the test bot successfully disconnects
+

--- a/test/unit/commands/settings.test.js
+++ b/test/unit/commands/settings.test.js
@@ -58,7 +58,8 @@ describe('Settings Command', () => {
 
   test.each([
     ['string', ['test-value'], '"test-value"'],
-    ['number', ['10'], 10],
+    ['number', ['10.5'], 10.5],
+    ['integer', ['10'], 10],
     ['boolean', ['true'], true],
     ['boolean', ['false'], false],
     ['range', ['0'], 0],
@@ -82,6 +83,7 @@ describe('Settings Command', () => {
 
   test.each([
     ['number', ['foo']],
+    ['integer', ['10.5']],
     ['boolean', ['not-boolean']],
     ['range', ['-1']],
     ['range', ['11']],

--- a/test/unit/commands/settings.test.js
+++ b/test/unit/commands/settings.test.js
@@ -56,6 +56,17 @@ describe('Settings Command', () => {
     expect(MOCK_BOT.message.reply).toHaveBeenCalledWith(expect.stringContaining(`"bot": { "prefix": "${newPrefix}" }`));
   });
 
+  test('resets server settings via `!settings reset`', async () => {
+    const setupArgs = ['!settings', 'test', 'boolean', 'true'];
+    const resetArgs = ['!settings', 'reset', 'test', 'boolean'];
+
+    await settingsCommand.run(MOCK_BOT, makeMockMessage(setupArgs), setupArgs);
+    expect(MOCK_BOT.guildOverrides[MOCK_GUILD_ID].test.boolean).toBe(true);
+
+    await settingsCommand.run(MOCK_BOT, makeMockMessage(resetArgs), resetArgs);
+    expect(MOCK_BOT.guildOverrides[MOCK_GUILD_ID].test.boolean).toBeUndefined();
+  });
+
   test.each([
     ['string', ['test-value'], '"test-value"'],
     ['number', ['10.5'], 10.5],


### PR DESCRIPTION
Available commands:

```
!settings <scope> <setting> <value> - This sets `scope.setting` to `value`
!settings list - Lists all possible settings that can be configured
!settings show - Lists current configuration in server
!settings reset - Resets/removes a given configuration in server
```

Closes #84 